### PR TITLE
Use sha256 library to support browser environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.3-alpha.1] - 2023-05-05
+
+### Fixed
+
+- Browser environments support ([PR](https://github.com/getjoystick/joystick-js/pull/5)).
+  Package `@peculiar/webcrypto` is replaced with `crypto-js`
+
 ## [0.1.2] - 2023-04-26
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,11 @@
       "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/webcrypto": "^1.4.3",
-        "axios": "^1.3.4"
+        "axios": "^1.3.4",
+        "crypto-js": "^4.1.1"
       },
       "devDependencies": {
+        "@types/crypto-js": "^4.1.1",
         "@types/jest": "^29.4.0",
         "@typescript-eslint/eslint-plugin": "^5.58.0",
         "@typescript-eslint/parser": "^5.58.0",
@@ -1486,42 +1487,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@peculiar/asn1-schema": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.6.tgz",
-      "integrity": "sha512-izNRxPoaeJeg/AyH8hER6s+H7p4itk+03QCa4sbxI3lNdseQYCuxzgsuNK8bTXChtLTjpJz6NmXKA73qLa3rCA==",
-      "dependencies": {
-        "asn1js": "^3.0.5",
-        "pvtsutils": "^1.3.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@peculiar/json-schema": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
-      "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
-      "dependencies": {
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@peculiar/webcrypto": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.4.3.tgz",
-      "integrity": "sha512-VtaY4spKTdN5LjJ04im/d/joXuvLbQdgy5Z4DXF4MFZhQ+MTrejbNMkfZBp1Bs3O5+bFqnJgyGdPuZQflvIa5A==",
-      "dependencies": {
-        "@peculiar/asn1-schema": "^2.3.6",
-        "@peculiar/json-schema": "^1.1.12",
-        "pvtsutils": "^1.3.2",
-        "tslib": "^2.5.0",
-        "webcrypto-core": "^1.7.7"
-      },
-      "engines": {
-        "node": ">=10.12.0"
-      }
-    },
     "node_modules/@sinclair/typebox": {
       "version": "0.25.24",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.24.tgz",
@@ -1586,6 +1551,12 @@
       "dependencies": {
         "@babel/types": "^7.3.0"
       }
+    },
+    "node_modules/@types/crypto-js": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@types/crypto-js/-/crypto-js-4.1.1.tgz",
+      "integrity": "sha512-BG7fQKZ689HIoc5h+6D2Dgq1fABRa0RbBWKBd9SP/MVRVXROflpm5fhwyATX5duFmbStzyzyycPB8qUYKDH3NA==",
+      "dev": true
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.6",
@@ -2081,19 +2052,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/asn1js": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.5.tgz",
-      "integrity": "sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==",
-      "dependencies": {
-        "pvtsutils": "^1.3.2",
-        "pvutils": "^1.1.3",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -2533,6 +2491,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
+      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -4960,22 +4923,6 @@
         }
       ]
     },
-    "node_modules/pvtsutils": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.2.tgz",
-      "integrity": "sha512-+Ipe2iNUyrZz+8K/2IOo+kKikdtfhRKzNpQbruF2URmqPtoqAs8g3xS7TJvFF2GcPXjh7DkqMnpVveRFq4PgEQ==",
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/pvutils": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
-      "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ==",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -5561,11 +5508,6 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
-    "node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-    },
     "node_modules/tsup": {
       "version": "6.7.0",
       "resolved": "https://registry.npmjs.org/tsup/-/tsup-6.7.0.tgz",
@@ -5809,18 +5751,6 @@
       "dev": true,
       "dependencies": {
         "makeerror": "1.0.12"
-      }
-    },
-    "node_modules/webcrypto-core": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.7.7.tgz",
-      "integrity": "sha512-7FjigXNsBfopEj+5DV2nhNpfic2vumtjjgPmeDKk45z+MJwXKKfhPB7118Pfzrmh4jqOMST6Ch37iPAHoImg5g==",
-      "dependencies": {
-        "@peculiar/asn1-schema": "^2.3.6",
-        "@peculiar/json-schema": "^1.1.12",
-        "asn1js": "^3.0.1",
-        "pvtsutils": "^1.3.2",
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@getjoystick/joystick-js",
-  "version": "0.1.2",
+  "version": "0.1.3-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@getjoystick/joystick-js",
-      "version": "0.1.2",
+      "version": "0.1.3-alpha.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "author": "getjoystick",
   "license": "MIT",
   "devDependencies": {
+    "@types/crypto-js": "^4.1.1",
     "@types/jest": "^29.4.0",
     "@typescript-eslint/eslint-plugin": "^5.58.0",
     "@typescript-eslint/parser": "^5.58.0",
@@ -47,8 +48,8 @@
     ]
   },
   "dependencies": {
-    "@peculiar/webcrypto": "^1.4.3",
-    "axios": "^1.3.4"
+    "axios": "^1.3.4",
+    "crypto-js": "^4.1.1"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjoystick/joystick-js",
-  "version": "0.1.2",
+  "version": "0.1.3-alpha.1",
   "description": "Javascript SDK for Joystick",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/internals/hash/sha256-to-hex.ts
+++ b/src/internals/hash/sha256-to-hex.ts
@@ -1,11 +1,4 @@
-import { Crypto } from "@peculiar/webcrypto";
-
-const crypto = new Crypto();
-
-const toHex = (hashBuffer: ArrayBuffer): string =>
-  Array.from(new Uint8Array(hashBuffer))
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
+import sha256 from "crypto-js/sha256";
 
 /**
  * The sha256ToHex function takes a string or array of unknowns and returns the SHA-256 hash of that data as a hexadecimal string.
@@ -19,12 +12,7 @@ const toHex = (hashBuffer: ArrayBuffer): string =>
 export async function sha256ToHex<TData extends string | unknown[]>(
   data: TData
 ): Promise<string> {
-  const massagedData = typeof data === "string" ? data : JSON.stringify(data);
+  const dataToBeHashed = typeof data === "string" ? data : JSON.stringify(data);
 
-  const hashBuffer = await crypto.subtle.digest(
-    "SHA-256",
-    new TextEncoder().encode(massagedData)
-  );
-
-  return toHex(hashBuffer);
+  return sha256(dataToBeHashed).toString();
 }


### PR DESCRIPTION
Currently, the library uses `@peculiar/webcrypto` for creating the hash for the cache key. Instead, we're going to use a native implementation of sha256 (using `crypto-js`), which will provide  compatibility with both Node.JS environment and Browser environments.